### PR TITLE
feat: implement issue #1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+JWT_ACCESS_SECRET=change-me-access-secret
+JWT_REFRESH_SECRET=change-me-refresh-secret
+DATABASE_PATH=./data/app.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+data/*.db
+data/*.db-*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # openclaw-test3
+
+ユーザー認証 REST API（Node.js + Express）の実装。
+
+## Features
+
+- `POST /api/auth/signup`
+- `POST /api/auth/login`
+- `GET /api/auth/me`
+- `POST /api/auth/refresh`
+- SQLite による users テーブル
+- bcrypt によるパスワードハッシュ化
+- JWT access / refresh token
+- express-validator による入力バリデーション
+
+## Response format
+
+成功:
+
+```json
+{ "data": { } }
+```
+
+失敗:
+
+```json
+{ "error": { "code": "...", "message": "..." } }
+```
+
+## Setup
+
+```bash
+cp .env.example .env
+npm install
+npm run db:init
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "openclaw-test3-auth-api",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "node src/server.js",
+    "db:init": "node src/db/init.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "better-sqlite3": "^11.7.0",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.0",
+    "express-validator": "^7.2.0",
+    "jsonwebtoken": "^9.0.2"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,30 @@
+require('dotenv').config();
+require('./db/init');
+
+const express = require('express');
+const authRoutes = require('./routes/auth');
+
+const app = express();
+
+app.use(express.json());
+
+app.get('/health', (_req, res) => {
+  res.status(200).json({ data: { status: 'ok' } });
+});
+
+app.use('/api/auth', authRoutes);
+
+app.use((req, res) => {
+  res.status(404).json({
+    error: { code: 'NOT_FOUND', message: 'Route not found' },
+  });
+});
+
+app.use((error, _req, res, _next) => {
+  console.error(error);
+  res.status(500).json({
+    error: { code: 'INTERNAL_SERVER_ERROR', message: 'Internal server error' },
+  });
+});
+
+module.exports = app;

--- a/src/db/connection.js
+++ b/src/db/connection.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const databasePath = process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db');
+fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+
+const db = new Database(databasePath);
+db.pragma('journal_mode = WAL');
+
+module.exports = db;

--- a/src/db/init.js
+++ b/src/db/init.js
@@ -1,0 +1,17 @@
+require('dotenv').config();
+const db = require('./connection');
+
+const createUsersTableSql = `
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+`;
+
+db.exec(createUsersTableSql);
+
+console.log('Database initialized');

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,31 @@
+const { verifyAccessToken } = require('../utils/jwt');
+const { findById } = require('../models/user');
+
+module.exports = function authMiddleware(req, res, next) {
+  const header = req.headers.authorization || '';
+  const [scheme, token] = header.split(' ');
+
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({
+      error: { code: 'UNAUTHORIZED', message: 'Missing or invalid authorization header' },
+    });
+  }
+
+  try {
+    const payload = verifyAccessToken(token);
+    const user = findById(payload.sub);
+
+    if (!user) {
+      return res.status(401).json({
+        error: { code: 'UNAUTHORIZED', message: 'User not found' },
+      });
+    }
+
+    req.user = user;
+    next();
+  } catch (error) {
+    return res.status(401).json({
+      error: { code: 'UNAUTHORIZED', message: 'Invalid or expired access token' },
+    });
+  }
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,0 +1,37 @@
+const db = require('../db/connection');
+
+function mapUser(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function findByEmail(email) {
+  return db.prepare('SELECT * FROM users WHERE email = ?').get(email);
+}
+
+function findById(id) {
+  const row = db.prepare('SELECT id, email, name, created_at, updated_at FROM users WHERE id = ?').get(id);
+  return mapUser(row);
+}
+
+function createUser({ email, passwordHash, name }) {
+  const stmt = db.prepare(`
+    INSERT INTO users (email, password_hash, name)
+    VALUES (@email, @passwordHash, @name)
+  `);
+
+  const result = stmt.run({ email, passwordHash, name });
+  return findById(result.lastInsertRowid);
+}
+
+module.exports = {
+  findByEmail,
+  findById,
+  createUser,
+};

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,136 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const { body, validationResult } = require('express-validator');
+const authMiddleware = require('../middleware/auth');
+const { findByEmail, findById, createUser } = require('../models/user');
+const { signAccessToken, signRefreshToken, verifyRefreshToken } = require('../utils/jwt');
+
+const router = express.Router();
+const SALT_ROUNDS = 10;
+
+function validationError(res, errors) {
+  return res.status(400).json({
+    error: {
+      code: 'VALIDATION_ERROR',
+      message: errors.array()[0].msg,
+    },
+  });
+}
+
+router.post(
+  '/signup',
+  [
+    body('email').isEmail().withMessage('Valid email is required'),
+    body('password').isLength({ min: 8 }).withMessage('Password must be at least 8 characters long'),
+    body('name').trim().notEmpty().withMessage('Name is required'),
+  ],
+  async (req, res, next) => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) return validationError(res, errors);
+
+      const { email, password, name } = req.body;
+      const existing = findByEmail(email.toLowerCase());
+      if (existing) {
+        return res.status(409).json({
+          error: { code: 'EMAIL_ALREADY_EXISTS', message: 'Email is already registered' },
+        });
+      }
+
+      const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+      const user = createUser({ email: email.toLowerCase(), passwordHash, name: name.trim() });
+      const accessToken = signAccessToken(user);
+      const refreshToken = signRefreshToken(user);
+
+      return res.status(201).json({
+        data: { user, accessToken, refreshToken },
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+router.post(
+  '/login',
+  [
+    body('email').isEmail().withMessage('Valid email is required'),
+    body('password').notEmpty().withMessage('Password is required'),
+  ],
+  async (req, res, next) => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) return validationError(res, errors);
+
+      const { email, password } = req.body;
+      const existing = findByEmail(email.toLowerCase());
+      if (!existing) {
+        return res.status(401).json({
+          error: { code: 'INVALID_CREDENTIALS', message: 'Invalid email or password' },
+        });
+      }
+
+      const matches = await bcrypt.compare(password, existing.password_hash);
+      if (!matches) {
+        return res.status(401).json({
+          error: { code: 'INVALID_CREDENTIALS', message: 'Invalid email or password' },
+        });
+      }
+
+      const user = findById(existing.id);
+      const accessToken = signAccessToken(user);
+      const refreshToken = signRefreshToken(user);
+
+      return res.status(200).json({
+        data: { user, accessToken, refreshToken },
+      });
+    } catch (error) {
+      return next(error);
+    }
+  }
+);
+
+router.get('/me', authMiddleware, (req, res) => {
+  return res.status(200).json({
+    data: { user: req.user },
+  });
+});
+
+router.post(
+  '/refresh',
+  [body('refreshToken').notEmpty().withMessage('refreshToken is required')],
+  (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) return validationError(res, errors);
+
+    try {
+      const { refreshToken } = req.body;
+      const payload = verifyRefreshToken(refreshToken);
+      if (payload.type !== 'refresh') {
+        return res.status(401).json({
+          error: { code: 'INVALID_TOKEN', message: 'Invalid refresh token' },
+        });
+      }
+
+      const user = findById(payload.sub);
+      if (!user) {
+        return res.status(401).json({
+          error: { code: 'INVALID_TOKEN', message: 'Invalid refresh token' },
+        });
+      }
+
+      const accessToken = signAccessToken(user);
+      const nextRefreshToken = signRefreshToken(user);
+
+      return res.status(200).json({
+        data: { accessToken, refreshToken: nextRefreshToken },
+      });
+    } catch (error) {
+      return res.status(401).json({
+        error: { code: 'INVALID_TOKEN', message: 'Invalid or expired refresh token' },
+      });
+    }
+  }
+);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,9 @@
+require('dotenv').config();
+
+const app = require('./app');
+
+const port = process.env.PORT || 3000;
+
+app.listen(port, () => {
+  console.log(`Server listening on http://localhost:${port}`);
+});

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,39 @@
+const jwt = require('jsonwebtoken');
+
+const ACCESS_EXPIRES_IN = '15m';
+const REFRESH_EXPIRES_IN = '7d';
+
+function getAccessSecret() {
+  return process.env.JWT_ACCESS_SECRET || 'change-me-access-secret';
+}
+
+function getRefreshSecret() {
+  return process.env.JWT_REFRESH_SECRET || 'change-me-refresh-secret';
+}
+
+function signAccessToken(user) {
+  return jwt.sign({ sub: user.id, email: user.email }, getAccessSecret(), {
+    expiresIn: ACCESS_EXPIRES_IN,
+  });
+}
+
+function signRefreshToken(user) {
+  return jwt.sign({ sub: user.id, email: user.email, type: 'refresh' }, getRefreshSecret(), {
+    expiresIn: REFRESH_EXPIRES_IN,
+  });
+}
+
+function verifyAccessToken(token) {
+  return jwt.verify(token, getAccessSecret());
+}
+
+function verifyRefreshToken(token) {
+  return jwt.verify(token, getRefreshSecret());
+}
+
+module.exports = {
+  signAccessToken,
+  signRefreshToken,
+  verifyAccessToken,
+  verifyRefreshToken,
+};


### PR DESCRIPTION
Fixes #1

## Issue
ユーザー認証 REST API（Node.js + Express） - DB設計

## Description
## 概要

このIssueは **ユーザー認証 REST API（Node.js + Express）** の実装タスクです。

## 詳細

| 項目 | 値 |
|------|-----|
| Project | openclaw-test3 |
| Spec | ユーザー認証 REST API（Node.js + Express） (technical_spec) |
| Priority | medium |
| Status | in_progress |

## 関連

- Notion Spec: https://www.notion.so/32f0505fb97481f1b505ff3da6dc344e

## Spec本文（自動抽出: title/rich_text 全プロパティ）

### Summary

Node.js + Express でユーザー認証 REST API を構築する。

### Implementation Notes

ディレクトリ構成:
src/
 app.js — Express アプリ初期化
 server.js — サーバー起動
 routes/auth.js — 認証ルート
 middleware/auth.js — JWT 検証ミドルウェア
 models/user.js — User モデル（DB操作）
 utils/jwt.js — JWT 生成・検証ユーティリティ
 db/init.js — DB 初期化・マイグレーション
package.json
.env.example
README.md

### Requirements

技術スタック:
- Node.js + Express
- JWT (jsonwebtoken)
- bcrypt（パスワードハッシュ）
- SQLite（sqlite3 / better-sqlite3）— 軽量DB
- express-validator（入力バリデーション）

エンドポイント:
1. POST /api/auth/signup — ユーザー登録（email, password, name）
2. POST /api/auth/login — ログイン（email, password）→ JWT 返却
3. GET /api/auth/me — 認証済みユーザー情報取得（Authorization: Bearer <token>）
4. POST /api/auth/refresh — トークンリフレッシュ

DB スキーマ（users テーブル）:
- id: INTEGER PRIMARY KEY AUTOINCREMENT
- email: TEXT UNIQUE NOT NULL
- password_hash: TEXT NOT NULL
- name: TEXT NOT NULL
- created_at: TEXT DEFAULT CURRENT_TIMESTAMP
- updated_at: TEXT DEFAULT CURRENT_TIMESTAMP

要件:
- パスワードは bcrypt でハッシュ化（salt rounds: 10）
- JWT の有効期限: access token 15分、refresh token 7日
- email フォーマットバリデーション
- パスワード最低8文字
- エラーレスポンスは統一フォーマット: { "error": { "code": "...", "message": "..." } }
- 成功レスポンス: { "data": { ... } }


Issue: https://github.com/bbbyk105/openclaw-test3/issues/1